### PR TITLE
Create Netlify Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # register.geoconnex.us
 
-The Geoconnex Registration Service makes it easy to contribute PIDs to geoconnex.us without a GitHub Account.
+The Geoconnex registration service makes it easy to contribute PIDs to geoconnex.us without a GitHub Account.
 
 ## Project Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# register.geoconnex.us
+# [register.geoconnex.us](register.geoconnex.us)
 
-The Geoconnex registration service makes it easy to contribute PIDs to geoconnex.us without a GitHub Account.
+[![Netlify Status](https://api.netlify.com/api/v1/badges/b9f97f51-0ce1-4131-9d8a-69ded110cd46/deploy-status)](https://app.netlify.com/sites/register-geoconnex-us/deploys)
+
+The Geoconnex registration service makes it easy to contribute PIDs to [geoconnex.us](https://geoconnex.us) without a GitHub Account.
 
 ## Project Setup
 

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -17,9 +17,7 @@ export class Config {
   static baseBranch: string = 'master'
 }
 
-console.log(import.meta.env.VUE_APP_REPO)
-
-console.log('Sending to API: ' + Config.repo, Config.token())
+console.log('Sending to API: ' + Config.repo)
 
 async function createBranch(
   headers: HeadersInit,


### PR DESCRIPTION
# Description

Github pages currently doesn't support branch previews without external actions. Netlify works better for this. I am switching the deploy to be to netlify instead of github pages. That allows us to get deploy previews and it will show in the CI pipeline red if it fails.

This should hopefully make it easier for Kyle/Ben to review PRs without needing to clone locally