### PR TITLE
Stricter ts

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,8 +14,4 @@
       "@/*": ["./src/*"]
     }
   }
-  // Can't find a way to get this working with vuetify
-  // "vueCompilerOptions": {
-  //   "strictTemplates": true,
-  // }
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,9 @@
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strict": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,9 +8,14 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strict": true,
+    "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
   }
+  // Can't find a way to get this working with vuetify
+  // "vueCompilerOptions": {
+  //   "strictTemplates": true,
+  // }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -13,6 +13,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "noImplicitThis": true,
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "strict": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,7 +11,9 @@
     "composite": true,
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strict": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": ["node"]


### PR DESCRIPTION
# Description

Adds stricter TS for the purpose of catching more errors during build time.

# Additional Notes

wanted to add typing for vuetify and strict templates but can't figure out how to fix build errors after adding the following to the tsconfig
```
 // Can't find a way to get this working with vuetify
   "vueCompilerOptions": {
     "strictTemplates": true,
   }
```


Importing the types manually do not work and putting the types in the tsconfig as manual imports don't work either. Will note this for later.

```
src/components/UploadForm.vue:114:20 - error TS2339: Property 'VTextField' does not exist on type '{}'.

114                   <v-text-field
                       ~~~~~~~~~~

src/components/UploadForm.vue:123:20 - error TS2339: Property 'VTextField' does not exist on type '{}'.

123                   <v-text-field
                       ~~~~~~~~~~

src/components/UploadForm.vue:131:20 - error TS2339: Property 'VTextField' does not exist on type '{}'.

131                   <v-text-field
                       ~~~~~~~~~~

src/components/UploadForm.vue:142:16 - error TS2339: Property 'VCol' does not exist on type '{}'.

142               <v-col cols="12" class="text-center">
                   ~~~~
```