### PR TITLE
Fix error for null namespace and use pinia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/papaparse": "^5.3.14",
         "papaparse": "^5.4.1",
-        "pinia": "^2.2.1",
+        "pinia": "^2.2.2",
         "vue": "^3.4.29",
         "vue-router": "^4.3.3",
         "vuetify": "^3.6.10"
@@ -3141,9 +3141,9 @@
       }
     },
     "node_modules/pinia": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.1.tgz",
-      "integrity": "sha512-ltEU3xwiz5ojVMizdP93AHi84Rtfz0+yKd8ud75hr9LVyWX2alxp7vLbY1kFm7MXFmHHr/9B08Xf8Jj6IHTEiQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.2.tgz",
+      "integrity": "sha512-ja2XqFWZC36mupU4z1ZzxeTApV7DOw44cV4dhQ9sGwun+N89v/XP7+j7q6TanS1u1tdbK4r+1BUx7heMaIdagA==",
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/papaparse": "^5.3.14",
     "papaparse": "^5.4.1",
-    "pinia": "^2.2.1",
+    "pinia": "^2.2.2",
     "vue": "^3.4.29",
     "vue-router": "^4.3.3",
     "vuetify": "^3.6.10"

--- a/src/components/MetadataGenerator.vue
+++ b/src/components/MetadataGenerator.vue
@@ -15,7 +15,6 @@ const contact_email = ref('')
 const readmeAlreadyUploaded = ref(false)
 const existingNamespaces = ref<string[]>([])
 
-
 onMounted(async () => {
   existingNamespaces.value = await fetchAllNamespaces()
 })
@@ -25,7 +24,7 @@ const isFormValid = computed(() => {
     return { type: 'error', text: 'Namespace is required' }
   }
 
-  if (state.namespace.length === 0) return { type: 'error', text: 'Namespace is required' } 
+  if (state.namespace.length === 0) return { type: 'error', text: 'Namespace is required' }
 
   if (!readmeAlreadyUploaded.value) {
     const requiredReadmeFields: MarkdownSection[] = [
@@ -38,7 +37,8 @@ const isFormValid = computed(() => {
     ]
 
     for (const field of requiredReadmeFields) {
-      if (field.body.length === 0) return { type: 'error', text: `${field.sectionName} is required` }
+      if (field.body.length === 0)
+        return { type: 'error', text: `${field.sectionName} is required` }
     }
   }
 
@@ -52,7 +52,7 @@ watch(isFormValid, (newVal) => {
 
 function setReadme() {
   if (isFormValid.value.type !== 'success') {
-    return 
+    return
   }
 
   if (!readmeAlreadyUploaded.value) {

--- a/src/components/UploadForm.vue
+++ b/src/components/UploadForm.vue
@@ -12,19 +12,22 @@ import type { ValidationReport } from '@/lib/types'
 const state = useFormStore()
 
 const checkResult = reactive({
-  type: undefined as 'Issues checking CSV' | 'Error submitting data' | 'Checked CSV without errors' | 'No errors checking CSV' | undefined,
+  type: undefined as
+    | 'Issues checking CSV'
+    | 'Error submitting data'
+    | 'Checked CSV without errors'
+    | 'No errors checking CSV'
+    | undefined,
   description: '',
   level: undefined as 'error' | 'warning' | 'info' | 'success' | undefined
 })
-
 
 const result = ref('')
 const progress = reactive({ running: false, action: '' })
 const crawlErrors = ref<ValidationReport['crawlErrors']>([])
 
-
 watch([progress, checkResult], (newVal) => {
-  state.blockNext = newVal[0].running === true  || newVal[1].type === 'Issues checking CSV'
+  state.blockNext = newVal[0].running === true || newVal[1].type === 'Issues checking CSV'
 })
 
 async function checkCSV() {
@@ -52,7 +55,8 @@ async function checkCSV() {
     return false
   } else {
     checkResult.type = 'Checked CSV without errors'
-    checkResult.description = 'Note: automated tests do not check regex URLs. If you have these, please validate any complex logic independently.'
+    checkResult.description =
+      'Note: automated tests do not check regex URLs. If you have these, please validate any complex logic independently.'
     checkResult.level = 'info'
     progress.running = false
     progress.action = ''

--- a/src/components/UploadForm.vue
+++ b/src/components/UploadForm.vue
@@ -1,9 +1,100 @@
-<!-- eslint-disable vue/valid-v-slot -->
 <script setup lang="ts">
+import { ref, reactive, watch } from 'vue'
 import URLCheckSummary from '@/components/URLCheckSummary.vue'
 import CSVReference from '@/components/CSVReference.vue'
 import GeoconnexBackground from '@/components/GeoconnexBackground.vue'
 import MetadataGenerator from '@/components/MetadataGenerator.vue'
+import { useFormStore } from '@/stores/formStore'
+import { validGeoconnexCSV } from '@/lib/helpers'
+import { submitData } from '@/lib/upload'
+import type { ValidationReport } from '@/lib/types'
+
+const state = useFormStore()
+
+const checkResult = reactive({
+  type: undefined as 'Issues checking CSV' | 'Error submitting data' | 'Checked CSV without errors' | 'No errors checking CSV' | undefined,
+  description: '',
+  level: undefined as 'error' | 'warning' | 'info' | 'success' | undefined
+})
+
+
+const result = ref('')
+const progress = reactive({ running: false, action: '' })
+const crawlErrors = ref<ValidationReport['crawlErrors']>([])
+
+
+watch([progress, checkResult], (newVal) => {
+  state.blockNext = newVal[0].running === true  || newVal[1].type === 'Issues checking CSV'
+})
+
+async function checkCSV() {
+  progress.running = true
+  progress.action = 'Validating your CSV data. This may take a minute...'
+
+  if (!state.csv) {
+    checkResult.type = 'Issues checking CSV'
+    checkResult.description = 'CSV file is required'
+    checkResult.level = 'warning'
+    progress.running = false
+    progress.action = ''
+    return false
+  }
+
+  const { valid, errorSummary, crawlErrors: errors } = await validGeoconnexCSV(state.csv)
+  crawlErrors.value = errors
+
+  if (!valid) {
+    checkResult.type = 'Issues checking CSV'
+    checkResult.description = errorSummary
+    checkResult.level = 'warning'
+    progress.running = false
+    progress.action = ''
+    return false
+  } else {
+    checkResult.type = 'Checked CSV without errors'
+    checkResult.description = 'Note: automated tests do not check regex URLs. If you have these, please validate any complex logic independently.'
+    checkResult.level = 'info'
+    progress.running = false
+    progress.action = ''
+    return true
+  }
+}
+
+function overrideError() {
+  checkResult.type = undefined
+  checkResult.description = ''
+  checkResult.level = undefined
+  crawlErrors.value = []
+  progress.running = false
+}
+
+async function submitForm() {
+  result.value = ''
+  progress.running = false
+  progress.action = ''
+
+  if (!state.csv) {
+    checkResult.type = 'Error submitting data'
+    checkResult.description = 'CSV file is required'
+    checkResult.level = 'error'
+    return
+  }
+
+  try {
+    progress.running = true
+    progress.action = 'Uploading your data to the Geoconnex registry.'
+    const submissionResult = await submitData(state.namespace, state.csv, state.readme)
+    result.value = submissionResult
+  } catch (error) {
+    checkResult.type = 'Error submitting data'
+    checkResult.description = error instanceof Error ? error.message : String(error)
+    checkResult.level = 'error'
+    result.value = ''
+  } finally {
+    progress.running = false
+    progress.action = ''
+  }
+}
 </script>
 
 <template>
@@ -17,7 +108,7 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
             'Step 3: Add CSV',
             'Step 4: Submit'
           ]"
-          :hide-actions="hideNext"
+          :hide-actions="state.blockNext"
           color="header"
         >
           <template v-slot:item.1>
@@ -26,8 +117,7 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
 
           <template v-slot:item.2>
             <h2 class="mb-4 text-center">Add Metadata for your CSV Contribution</h2>
-
-            <MetadataGenerator :namespace="namespace" @result="setMetadata" />
+            <MetadataGenerator />
           </template>
 
           <template v-slot:item.3>
@@ -40,7 +130,7 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
             </p>
 
             <v-file-input
-              v-model="csv"
+              v-model="state.csv"
               label="CSV Mapping"
               accept=".csv"
               required
@@ -60,11 +150,11 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
 
             <v-fade-transition class="mx-auto w-66">
               <v-alert
-                :color="checkError.level || 'error'"
-                :icon="`$${checkError.level || 'error'}`"
-                :title="checkError.type"
-                :text="checkError.text"
-                v-if="checkError.type && !progress.running"
+                :color="checkResult.level || 'error'"
+                :icon="`$${checkResult.level || 'error'}`"
+                :title="checkResult.type"
+                :text="checkResult.description"
+                v-if="checkResult.type && !progress.running"
               >
               </v-alert>
               <v-alert
@@ -72,12 +162,12 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
                 icon="$success"
                 title="Data mapping submitted"
                 :text="result"
-                v-if="checkError.type == null && result && !progress.running"
+                v-if="checkResult.type == null && result && !progress.running"
               ></v-alert>
             </v-fade-transition>
 
             <v-btn
-              v-if="checkError.type === 'Issues Checking CSV' && !progress.running"
+              v-if="checkResult.type === 'Issues checking CSV' && !progress.running"
               @click="overrideError"
               class="my-6 d-flex mx-auto ignoreButton"
             >
@@ -107,13 +197,13 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
 
             <v-fade-transition class="mt-4 mx-auto w-66">
               <v-alert
-                :color="checkError.level || 'error'"
-                :icon="`$${checkError.level || 'error'}`"
-                :title="checkError.type"
-                :text="checkError.text"
+                :color="checkResult.level || 'error'"
+                :icon="`$${checkResult.level || 'error'}`"
+                :title="checkResult.type"
+                :text="checkResult.description"
                 v-if="
-                  checkError.type != 'Checked CSV without errors' &&
-                  checkError.type &&
+                  checkResult.type != 'Checked CSV without errors' &&
+                  checkResult.type &&
                   !progress.running
                 "
               >
@@ -123,7 +213,7 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
                 icon="$success"
                 title="Data Submitted"
                 :text="result"
-                v-if="checkError.type == null && result && !progress.running"
+                v-if="checkResult.type == null && result && !progress.running"
               ></v-alert>
             </v-fade-transition>
 
@@ -136,123 +226,6 @@ import MetadataGenerator from '@/components/MetadataGenerator.vue'
     </v-row>
   </v-container>
 </template>
-
-<script lang="ts">
-import { submitData } from '@/lib/upload'
-import { defineComponent } from 'vue'
-import { validGeoconnexCSV } from '@/lib/helpers'
-import type { ValidationReport } from '@/lib/types'
-
-interface CheckError {
-  type: 'Issues Checking CSV' | 'Error submitting data' | 'Checked CSV without errors' | undefined
-  text: string
-  level?: 'error' | 'warning' | 'info'
-}
-
-export default defineComponent({
-  data() {
-    return {
-      namespace: '',
-      csv: null as File | null,
-      readme: null as File | null,
-      checkError: {} as CheckError,
-      result: '',
-      progress: { running: false, action: '' },
-      crawlErrors: [] as ValidationReport['crawlErrors'],
-      existingNamespaces: [] as string[],
-      blockNext: false
-    }
-  },
-  computed: {
-    hideNext() {
-      return (
-        this.checkError.type === 'Issues Checking CSV' || this.progress.running || this.blockNext
-      )
-    }
-  },
-
-  methods: {
-    async checkCSV() {
-      this.progress = {
-        running: true,
-        action: 'Validating your CSV data. This may take a minute...'
-      }
-
-      if (!this.csv) {
-        return
-      }
-      const { valid, errorSummary, crawlErrors } = await validGeoconnexCSV(this.csv)
-      this.crawlErrors = crawlErrors
-
-      if (!valid) {
-        if (this.crawlErrors !== undefined) {
-          this.progress = { running: false, action: '' }
-          this.checkError = {
-            type: 'Issues Checking CSV',
-            text: errorSummary as string,
-            level: 'warning'
-          }
-          return false
-        }
-      } else {
-        this.checkError = {
-          type: 'Checked CSV without errors',
-          text: 'Note: automated tests do not check regex URLs. If you have these, please validate any complex logic independently.',
-          level: 'info'
-        }
-        this.progress = { running: false, action: '' }
-        return true
-      }
-    },
-
-    async valid() {
-      if (!this.csv) {
-        return false
-      }
-
-      this.progress = {
-        running: true,
-        action: 'Validating your CSV data. This may take a minute...'
-      }
-    },
-    overrideError() {
-      this.checkError = { type: undefined, text: '' }
-      this.crawlErrors = []
-    },
-    setMetadata(metadata: { readme: File | null; namespace: string; blockNext?: boolean }) {
-      const { readme, namespace, blockNext } = metadata
-      this.namespace = namespace
-      this.readme = readme
-      this.blockNext = blockNext || false
-    },
-
-    async submitForm() {
-      // reset stored form state at the start of the submission before validating
-      this.result = ''
-      this.progress = { running: false, action: '' }
-
-      if (!this.csv) {
-        this.checkError = { type: 'Error submitting data', text: 'CSV file is required' }
-        return
-      }
-
-      try {
-        this.progress = { running: true, action: 'Uploading your data to the Geoconnex registry.' }
-        const result = await submitData(this.namespace, this.csv, this.readme || undefined)
-        this.result = result
-      } catch (error) {
-        this.checkError = {
-          type: 'Error submitting data',
-          text: error instanceof Error ? error.message : String(error)
-        }
-        this.result = ''
-      }
-
-      this.progress = { running: false, action: '' }
-    }
-  }
-})
-</script>
 
 <style scoped>
 .ignoreButton {

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -131,7 +131,7 @@ export async function createPR(
   return prResponse
 }
 
-export async function submitData(namespace: string, file: File, readme?: File): Promise<string> {
+export async function submitData(namespace: string, file: File, readme: File | null): Promise<string> {
   const token = Config.token()
 
   const headers = {
@@ -161,7 +161,7 @@ export async function submitData(namespace: string, file: File, readme?: File): 
     validatedSha
   )
 
-  if (readme) {
+  if (readme !== null) {
     const readmeContent = await readme.text()
     const readmeB64Content = btoa(readmeContent)
     const readmeFilePath = `namespaces/${namespace}/README.md`
@@ -171,6 +171,7 @@ export async function submitData(namespace: string, file: File, readme?: File): 
       readmeFilePath,
       readmeContent
     )
+    console.log("Uploading readme")
     await uploadData(
       headers,
       repo,

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -131,7 +131,11 @@ export async function createPR(
   return prResponse
 }
 
-export async function submitData(namespace: string, file: File, readme: File | null): Promise<string> {
+export async function submitData(
+  namespace: string,
+  file: File,
+  readme: File | null
+): Promise<string> {
   const token = Config.token()
 
   const headers = {
@@ -171,7 +175,7 @@ export async function submitData(namespace: string, file: File, readme: File | n
       readmeFilePath,
       readmeContent
     )
-    console.log("Uploading readme")
+    console.log('Uploading readme')
     await uploadData(
       headers,
       repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import App from './App.vue'
 import colors from 'vuetify/util/colors'
+import { createPinia } from 'pinia'
 
 const buttonColor = '#00A087'
 
@@ -47,5 +48,6 @@ const vuetify = createVuetify({
 const app = createApp(App)
 app.use(vuetify)
 app.use(router)
+app.use(createPinia())
 
 app.mount('#app')

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -1,0 +1,18 @@
+import { defineStore } from "pinia";
+
+
+export const useFormStore = defineStore("formStore", {
+    
+    state: () => ({
+        csv: null as File | null,
+
+        readme: null as File | null,
+
+        namespace : '' as string,
+
+        // Remove the next/previous buttons 
+        // if the form is an invalid state
+        blockNext : false,
+
+    }),
+})

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -1,18 +1,15 @@
-import { defineStore } from "pinia";
+import { defineStore } from 'pinia'
 
+export const useFormStore = defineStore('formStore', {
+  state: () => ({
+    csv: null as File | null,
 
-export const useFormStore = defineStore("formStore", {
-    
-    state: () => ({
-        csv: null as File | null,
+    readme: null as File | null,
 
-        readme: null as File | null,
+    namespace: '' as string,
 
-        namespace : '' as string,
-
-        // Remove the next/previous buttons 
-        // if the form is an invalid state
-        blockNext : false,
-
-    }),
+    // Remove the next/previous buttons
+    // if the form is an invalid state
+    blockNext: false
+  })
 })

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,6 +8,7 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strict": true,
+    "sourceMap": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,6 +9,7 @@
   ],
   "compilerOptions": {
     "composite": true,
+    "sourceMap": true,
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "noImplicitThis": true,


### PR DESCRIPTION
Refactors to use the composition API and pinia. No visual / template code is different, just state logic.

- instead of having refs that need to be emitted to the parent, we can use a store. This allows us to access certain variables that are relevant to multiple components that would otherwise be awkward to pass around
    - pinia has a lot of nice features and allows us to just `v-model` directly with the store value 
- uses the composition API to clean up the code a bit more